### PR TITLE
feat: update xray-core version to 1.8.11

### DIFF
--- a/xray-core/Makefile
+++ b/xray-core/Makefile
@@ -5,12 +5,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=xray-core
-PKG_VERSION:=1.8.8
+PKG_VERSION:=1.8.11
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/XTLS/Xray-core/tar.gz/v$(PKG_VERSION)?
-PKG_HASH:=156105b89465ca948971a774c0bc7e56ee68e764bdfde58923037dc837aab4be
+PKG_HASH:=d99ee6008c508abbad6bbb242d058b22efb50fb35867d15447a2b4602ab4b283
 
 PKG_MAINTAINER:=Tianling Shen <cnsztl@immortalwrt.org>
 PKG_LICENSE:=MPL-2.0

--- a/xray-core/patches/100-go-mod-ver.patch
+++ b/xray-core/patches/100-go-mod-ver.patch
@@ -4,7 +4,7 @@
  module github.com/xtls/xray-core
  
 -go 1.22
-+go 1.21.7
++go 1.21.9
  
  require (
- 	github.com/ghodss/yaml v1.0.1-0.20220118164431-d8423dcdf344
+ 	github.com/OmarTariq612/goech v0.0.0-20240405204721-8e2e1dafd3a0


### PR DESCRIPTION
This pull request updates the xray-core dependency from version v1.8.8-1 to v1.8.11. This update includes several critical enhancements including the support for HTTP/2 Upgrade protocol, alongside bug fixes, performance improvements, and security patches. These enhancements are essential for maintaining the reliability, efficiency, and security of the service.

Changes made:

    Updated the xray-core version in the Makefile from v1.8.8-1 to v1.8.11.

Key improvements:

    HTTP/2 Upgrade protocol support: Adds support for the HTTP/2 protocol upgrade, enhancing compatibility and performance with modern web services.
    Security enhancements: Incorporates the latest security patches to protect against vulnerabilities.
    Performance improvements: Improves the efficiency and stability of network components.
    Bug fixes: Addresses several known issues from the previous version, enhancing user experience and system reliability.

Testing:
Comprehensive testing was conducted in the OpenWRT development environment to ensure that the upgrade supports all new features without compromising existing functionalities and that it operates seamlessly within our deployment scenario.

Additional notes:
For a detailed list of the features and bug fixes included in xray-core version v1.8.11, please refer to the [release notes on GitHub](https://github.com/xtls/xray-core/releases/tag/v1.8.11).

This update is crucial for keeping our project up-to-date with the latest standards and technologies, particularly for enhancing network protocol support and security. I recommend merging this pull request after sufficient review and testing by the project maintainers.